### PR TITLE
Fixes documentation in Message installer template

### DIFF
--- a/installer/new/templates/message.ex
+++ b/installer/new/templates/message.ex
@@ -32,7 +32,7 @@ defmodule <%= base %>.Message do
   end
 
   @doc """
-  A message acknowledging that the account has been successfully confirmed.
+  A message acknowledging that the account has been successfully resetted.
   """
   def reset_success(address) do
     address


### PR DESCRIPTION
Just a small documentation error. `Message.reset_success/1` is called when a reset was successful, not when a confirmation was successful. :)