### PR TITLE
Renames url in `Message.reset_request/2`

### DIFF
--- a/installer/new/templates/message.ex
+++ b/installer/new/templates/message.ex
@@ -20,8 +20,8 @@ defmodule <%= base %>.Message do
   A message with a link to reset the password.
   """
   def reset_request(address, key) do
-    confirm_url = "http://www.example.com/password_resets/edit?key=#{key}"
-    {address, confirm_url}
+    reset_url = "http://www.example.com/password_resets/edit?key=#{key}"
+    {address, reset_url}
   end
 
   @doc """


### PR DESCRIPTION
Just another tiny naming fix, that I found while reading through the code.

Thank you very much for this library, I enjoy working with it. :)