### PR TITLE
Adds email address param to the reset URL

### DIFF
--- a/installer/new/templates/message.ex
+++ b/installer/new/templates/message.ex
@@ -20,7 +20,7 @@ defmodule <%= base %>.Message do
   A message with a link to reset the password.
   """
   def reset_request(address, key) do
-    reset_url = "http://www.example.com/password_resets/edit?key=#{key}"
+    reset_url = "http://www.example.com/password_resets/edit?key=#{key}&email=#{address}"
     {address, reset_url}
   end
 


### PR DESCRIPTION
The password_reset_controller expects the key as well as the address: https://github.com/riverrun/phauxth/blob/master/installer/new/templates/password_reset_controller.ex#L31