### PR TITLE
Renew session after login to avoid session fixation attacks

### DIFF
--- a/installer/new/templates/session_controller.ex
+++ b/installer/new/templates/session_controller.ex
@@ -16,6 +16,7 @@ defmodule <%= base %>Web.SessionController do
       {:error, _message} ->
         error(conn, :unauthorized, 401)<% else %>
         put_session(conn, :user_id, user.id)
+        |> configure_session(renew: true)
         |> success("You have been logged in", user_path(conn, :index))
       {:error, message} ->
         error(conn, message, session_path(conn, :new))<% end %>


### PR DESCRIPTION
In the official Phoenix guides it is recommended to generate a new session id after a successful login, in order to prevent session fixation attacks.

See https://hexdocs.pm/phoenix/contexts.html#adding-account-functions