### PR TITLE
Change the way to get the current app's endpoint

### DIFF
--- a/lib/phauxth/config.ex
+++ b/lib/phauxth/config.ex
@@ -75,10 +75,16 @@ defmodule Phauxth.Config do
   """
   def endpoint do
     Application.get_env(:phauxth, :endpoint)
-    || Application.get_env(namespaced_phauxth(), :endpoint)
-    || raise """
-    You need to set the `endpoint` value in the config/config.exs file.
-    """
+    # || Application.get_env(namespaced_phauxth(), :endpoint)
+    # || raise """
+    # You need to set the `endpoint` value in the config/config.exs file.
+    # """
+
+    current_app_namespace =
+      Mix.Project.config[:app]
+      |> Atom.to_string
+      |> Macro.camelize
+    Module.concat([current_app_namespace, "Endpoint"])
   end
 
   @doc """

--- a/lib/phauxth/config.ex
+++ b/lib/phauxth/config.ex
@@ -74,7 +74,7 @@ defmodule Phauxth.Config do
   This is used by the Phauxth.Confirm module.
   """
   def endpoint do
-    Application.get_env(:phauxth, :endpoint)
+    # Application.get_env(:phauxth, :endpoint)
     # || Application.get_env(namespaced_phauxth(), :endpoint)
     # || raise """
     # You need to set the `endpoint` value in the config/config.exs file.


### PR DESCRIPTION
Instead to look for the configuration, the function now get the current app name and
build from it the actual namespaced endpoint