### PR TITLE
Use safe default email addresses

### DIFF
--- a/installer/new/templates/repo_seeds.exs
+++ b/installer/new/templates/repo_seeds.exs
@@ -6,8 +6,8 @@
 #
 
 users = [
-  %{email: "ted@mail.com", password: "password"},
-  %{email: "eddiebaby@mail.com", password: "password"}
+  %{email: "jane.doe@example.com", password: "password"},
+  %{email: "john.smith@example.org", password: "password"}
 ]
 
 for user <- users do<%= if confirm do %>


### PR DESCRIPTION
I found it strange and a bit worrisome when I saw real email addresses being used. Even when I realized they are supposed to be for fake/non-personal entities I prefer to keep examples like this safe.