### PR TITLE
Replaced term_to_binary / binary_to_term with Poison encode / decode

### DIFF
--- a/lib/phauxth/token.ex
+++ b/lib/phauxth/token.ex
@@ -58,8 +58,8 @@ defmodule Phauxth.Token do
   def sign(key_source, data, opts \\ []) do
     secret = get_key_base(key_source) |> validate_secret |> get_secret(opts)
 
-    %{data: data, signed: now_ms()}
-    |> :erlang.term_to_binary()
+    %{"data" => data, "signed" => now_ms()}
+    |> Poison.encode!
     |> MessageVerifier.sign(secret)
   end
 
@@ -75,7 +75,7 @@ defmodule Phauxth.Token do
 
     case MessageVerifier.verify(token, secret) do
       {:ok, message} ->
-        %{data: data, signed: signed} = Plug.Crypto.safe_binary_to_term(message)
+        %{"data" => data, "signed" => signed} = Poison.decode!(message)
 
         if (signed + max_age_ms) < now_ms() do
           {:error, "expired token"}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Phauxth.Mixfile do
   use Mix.Project
 
-  @version "1.1.0"
+  @version "1.1.1"
 
   @description """
   Authentication library for Phoenix, and other Plug-based, web applications
@@ -31,6 +31,7 @@ defmodule Phauxth.Mixfile do
     [
       {:plug, "~> 1.4"},
       {:comeonin, "~> 4.0"},
+      {:poison, "~> 3.1"},
       {:argon2_elixir, "~> 1.2", optional: true},
       {:bcrypt_elixir, "~> 0.12.1 or ~> 1.0", optional: true},
       {:pbkdf2_elixir, "~> 0.12", optional: true},


### PR DESCRIPTION
Using JSON instead of erlang's binary_to_term / term_to_binary functions.