### PR TITLE
Add guest_check/2 auth helper function

### DIFF
--- a/installer/new/templates/authorize.ex
+++ b/installer/new/templates/authorize.ex
@@ -25,6 +25,14 @@ defmodule <%= base %>Web.Authorize do
   end
   def user_check(conn, _opts), do: conn
 
+  # Plug to only allow unauthenticated users to access the resource.
+  # See the session controller for an example.
+  def guest_check(%Plug.Conn{assigns: %{current_user: nil}} = conn, _opts), do: conn
+  def guest_check(%Plug.Conn{assigns: %{current_user: _current_user}} = conn, _opts) do<%= if api do %>
+    error(conn, :unauthorized, 401)<% else %>
+    error(conn, "You need to log out to view this page", page_path(conn, :index))<% end %>
+  end
+
   # Plug to only allow authenticated users with the correct id to access the resource.
   # See the user controller for an example.
   def id_check(%Plug.Conn{assigns: %{current_user: nil}} = conn, _opts) do<%= if api do %>

--- a/installer/new/templates/session_controller.ex
+++ b/installer/new/templates/session_controller.ex
@@ -5,6 +5,8 @@ defmodule <%= base %>Web.SessionController do
   alias Phauxth.Confirm.Login<% else %>
   alias Phauxth.Login<% end %><%= if not api do %>
 
+  plug :guest_check when action in [:new, :create]
+
   def new(conn, _) do
     render(conn, "new.html")
   end<% end %>

--- a/installer/new/templates/session_controller_test.exs
+++ b/installer/new/templates/session_controller_test.exs
@@ -17,6 +17,12 @@ defmodule <%= base %>Web.SessionControllerTest do
     {:ok, %{conn: conn, user: user}}
   end
 
+  <%= if not api do %>test "rendering login form fails for user that is already logged in", %{conn: conn, user: user} do
+    conn = conn |> put_session(:user_id, user.id) |> send_resp(:ok, "/")
+    conn = get conn, session_path(conn, :new)
+    assert redirected_to(conn) == page_path(conn, :index)
+  end<% end %>
+
   test "login succeeds", %{conn: conn} do
     conn = post conn, session_path(conn, :create), session: @create_attrs<%= if api do %>
     assert json_response(conn, 200)["access_token"]<% else %>
@@ -29,6 +35,15 @@ defmodule <%= base %>Web.SessionControllerTest do
   end<% else %>
     assert redirected_to(conn) == session_path(conn, :new)
   end<% end %><% end %>
+
+
+  test "login fails for user that is already logged in", %{conn: conn, user: user} do
+    conn = conn |> put_session(:user_id, user.id) |> send_resp(:ok, "/")
+    conn = post conn, session_path(conn, :create), session: @create_attrs<%= if api do %>
+    assert json_response(conn, 401)
+  end<% else %>
+    assert redirected_to(conn) == page_path(conn, :index)
+  end<% end %>
 
   test "login fails for invalid password", %{conn: conn} do
     conn = post conn, session_path(conn, :create), session: @invalid_attrs<%= if api do %>


### PR DESCRIPTION
This PR adds the reverse function to `check_user/2`, because I think some action should not be allowed to be performed by logged in users.

For now, it makes sure that logged in users are not able to visit the login form again after being logged in. This can be very handy to prevent confusing situations, e.g. the user has the login form url in the browser's cache and visits it, even though the user is still logged in.

What do you think?