### PR TITLE
Replace user_context arg with config

### DIFF
--- a/lib/phauxth.ex
+++ b/lib/phauxth.ex
@@ -5,7 +5,7 @@ defmodule Phauxth do
   Phauxth is designed to be secure, extensible and well-documented.
 
   Phauxth offers two types of functions: Plugs, which are called with plug,
-  and verify/3 functions, which are called inside the function bodies.
+  and verify/2 functions, which are called inside the function bodies.
 
   ## Plugs
 
@@ -40,11 +40,10 @@ defmodule Phauxth do
 
   This needs to be called after `plug Phauxth.Authenticate`.
 
-  ## Phauxth verify/3
+  ## Phauxth verify/2
 
-  The verify/3 function takes a map (usually Phoenix params), a context
-  module (usually MyApp.Accounts) and opts (an empty list by default)
-  and returns {:ok, user} or {:error, message}.
+  The verify/2 function takes a map (usually Phoenix params) and opts (an empty
+  list by default) and returns {:ok, user} or {:error, message}.
 
   ### Login
 
@@ -52,7 +51,7 @@ defmodule Phauxth do
   in the session controller.
 
       def create(conn, %{"session" => params}) do
-        case Phauxth.Login.verify(params, MyApp.Accounts) do
+        case Phauxth.Login.verify(params) do
           {:ok, user} -> handle_successful_login
           {:error, message} -> handle_error
         end
@@ -71,7 +70,7 @@ defmodule Phauxth do
   confirm a user's account.
 
       def new(conn, params) do
-        case Phauxth.Confirm.verify(params, MyApp.Accounts) do
+        case Phauxth.Confirm.verify(params) do
           {:ok, user} ->
             Accounts.confirm_user(user)
             message = "Your account has been confirmed"
@@ -88,7 +87,7 @@ defmodule Phauxth do
   To use Phauxth.Confirm for password resetting add the `mode: :pass_reset`
   option to the verify function:
 
-      Phauxth.Confirm.verify(params, MyApp.Accounts, mode: :pass_reset)
+      Phauxth.Confirm.verify(params, mode: :pass_reset)
 
   This function just verifies the confirmation key. It does not reset
   the password or send an email to the user.
@@ -106,9 +105,10 @@ defmodule Phauxth do
     * `--api` - create files for an api
     * `--confirm` - add files for email confirmation
 
-  Phauxth uses the user context module (normally MyApp.Accounts) to communicate
-  with the underlying database. This module needs to have the `get(id)` and
-  `get_by(attrs)` functions defined (see the examples below).
+  Phauxth uses the user context module (normally MyApp.Accounts or config
+  user_context if given) to communicate with the underlying database. This
+  module needs to have the `get(id)` and `get_by(attrs)` functions defined
+  (see the examples below).
 
       def get(id), do: Repo.get(User, id)
 
@@ -126,6 +126,6 @@ defmodule Phauxth do
 
   """
 
-  @callback verify(params :: map, context :: atom, opts :: keyword | tuple) ::
+  @callback verify(params :: map, opts :: keyword | tuple) ::
               {:ok, user :: map} | {:error, message :: String.t()}
 end

--- a/lib/phauxth/config.ex
+++ b/lib/phauxth/config.ex
@@ -27,8 +27,11 @@ defmodule Phauxth.Config do
   And this example shows how the Confirm.verify function needs to be
   called:
 
-      Phauxth.Confirm.verify(params, MyApp.Accounts,
-        endpoint: MyAppWeb.Endpoint, token_salt: "somesalt")
+      Phauxth.Confirm.verify(params, [
+        user_context: MyApp.Accounts,
+        endpoint:     MyAppWeb.Endpoint,
+        token_salt:   "somesalt"
+      ])
 
   ## Examples
 
@@ -38,6 +41,7 @@ defmodule Phauxth.Config do
       config :phauxth,
         token_salt: "YkLmt7+f",
         endpoint: MyAppWeb.Endpoint,
+        user_context: MyApp.Accounts,
         log_level: :warn,
         drop_user_keys: [:shoe_size]
 

--- a/test/confirm_login_test.exs
+++ b/test/confirm_login_test.exs
@@ -4,7 +4,7 @@ defmodule Phauxth.Confirm.LoginTest do
 
   defp login(name, password, user_params \\ "email") do
     params = %{user_params => name, "password" => password}
-    Phauxth.Confirm.Login.verify(params, Phauxth.TestAccounts)
+    Phauxth.Confirm.Login.verify(params)
   end
 
   test "login succeeds if account has been confirmed" do

--- a/test/confirm_pass_reset_test.exs
+++ b/test/confirm_pass_reset_test.exs
@@ -3,7 +3,7 @@ defmodule Phauxth.Confirm.PassResetTest do
   use Plug.Test
   import ExUnit.CaptureLog
 
-  alias Phauxth.{Confirm, TestAccounts, Token}
+  alias Phauxth.{Confirm, Token}
 
   setup do
     conn = conn(:get, "/") |> Phauxth.SessionHelper.add_key()
@@ -13,13 +13,13 @@ defmodule Phauxth.Confirm.PassResetTest do
 
   test "reset password succeeds", %{valid_email: valid_email} do
     params = %{"key" => valid_email, "password" => "password"}
-    {:ok, user} = Confirm.verify(params, TestAccounts, mode: :pass_reset)
+    {:ok, user} = Confirm.verify(params, mode: :pass_reset)
     assert user
   end
 
   test "reset password fails with expired token", %{valid_email: valid_email} do
     params = %{"key" => valid_email, "password" => "password"}
-    {:error, message} = Confirm.verify(params, TestAccounts, max_age: -1, mode: :pass_reset)
+    {:error, message} = Confirm.verify(params, max_age: -1, mode: :pass_reset)
     assert message =~ "Invalid credentials"
   end
 
@@ -27,7 +27,7 @@ defmodule Phauxth.Confirm.PassResetTest do
     assert capture_log(fn ->
              valid_key = Token.sign(conn, %{"email" => "igor@example.com"})
              params = %{"key" => valid_key, "password" => "password"}
-             {:error, _} = Confirm.verify(params, TestAccounts, mode: :pass_reset)
+             {:error, _} = Confirm.verify(params, mode: :pass_reset)
            end) =~ ~s([warn]  user=nil message="no reset token found")
   end
 end

--- a/test/confirm_test.exs
+++ b/test/confirm_test.exs
@@ -3,7 +3,7 @@ defmodule Phauxth.ConfirmTest do
   use Plug.Test
   import ExUnit.CaptureLog
 
-  alias Phauxth.{Confirm, TestAccounts, Token}
+  alias Phauxth.{Confirm, Token}
 
   setup do
     conn = conn(:get, "/") |> Phauxth.SessionHelper.add_key()
@@ -13,55 +13,55 @@ defmodule Phauxth.ConfirmTest do
 
   test "confirmation succeeds for valid token", %{valid_email: valid_email} do
     %{params: params} = conn(:get, "/confirm?key=" <> valid_email) |> fetch_query_params
-    {:ok, user} = Confirm.verify(params, TestAccounts)
+    {:ok, user} = Confirm.verify(params)
     assert user.email == "fred+1@example.com"
   end
 
   test "confirmation fails for invalid token" do
     %{params: params} = conn(:get, "/confirm?key=invalidlink") |> fetch_query_params
-    {:error, message} = Confirm.verify(params, TestAccounts)
+    {:error, message} = Confirm.verify(params)
     assert message =~ "Invalid credentials"
   end
 
   test "confirmation fails for expired token", %{valid_email: valid_email} do
     %{params: params} = conn(:get, "/confirm?key=" <> valid_email) |> fetch_query_params
-    {:error, message} = Confirm.verify(params, TestAccounts, max_age: -1)
+    {:error, message} = Confirm.verify(params, max_age: -1)
     assert message =~ "Invalid credentials"
   end
 
   test "confirmation fails for already confirmed account", %{conn: conn} do
     confirmed_email = Token.sign(conn, %{"email" => "ray@example.com"})
     %{params: params} = conn(:get, "/confirm?key=" <> confirmed_email) |> fetch_query_params
-    {:error, message} = Confirm.verify(params, TestAccounts)
+    {:error, message} = Confirm.verify(params)
     assert message =~ "Your account has already been confirmed"
   end
 
   test "confirmation succeeds with different identifier", %{conn: conn} do
     valid_phone = Token.sign(conn, %{"phone" => "55555555555"})
     %{params: params} = conn(:get, "/confirm?key=" <> valid_phone) |> fetch_query_params
-    {:ok, user} = Confirm.verify(params, TestAccounts)
+    {:ok, user} = Confirm.verify(params)
     assert user.email == "fred+1@example.com"
   end
 
   test "confirm with custom metadata for logging", %{valid_email: valid_email} do
     assert capture_log(fn ->
              %{params: params} = conn(:get, "/confirm?key=" <> valid_email) |> fetch_query_params
-             {:ok, _} = Confirm.verify(params, TestAccounts, log_meta: [path: "/confirm"])
+             {:ok, _} = Confirm.verify(params, log_meta: [path: "/confirm"])
            end) =~ ~s(user=1 message="user confirmed" path=/confirm)
   end
 
   test "raises an error if no key is found in the params" do
     assert_raise ArgumentError, "No key found in the params", fn ->
-      {:ok, _} = Confirm.verify(%{"no_key" => "no_key"}, TestAccounts)
+      {:ok, _} = Confirm.verify(%{"no_key" => "no_key"})
     end
   end
 
   test "key options passed on to the Token module", %{conn: conn} do
     valid_phone = Token.sign(conn, %{"phone" => "55555555555"}, key_iterations: 10)
     %{params: params} = conn(:get, "/confirm?key=" <> valid_phone) |> fetch_query_params
-    {:ok, user} = Confirm.verify(params, TestAccounts, key_iterations: 10)
+    {:ok, user} = Confirm.verify(params, key_iterations: 10)
     assert user.email == "fred+1@example.com"
-    {:error, message} = Confirm.verify(params, TestAccounts)
+    {:error, message} = Confirm.verify(params)
     assert message =~ "Invalid credentials"
   end
 end

--- a/test/custom_confirm_test.exs
+++ b/test/custom_confirm_test.exs
@@ -2,7 +2,7 @@ defmodule Phauxth.CustomConfirmTest do
   use ExUnit.Case
   use Plug.Test
 
-  alias Phauxth.{CustomConfirm, TestAccounts, Token}
+  alias Phauxth.{CustomConfirm, Token}
 
   setup do
     conn = conn(:get, "/") |> Phauxth.SessionHelper.add_key()
@@ -12,7 +12,7 @@ defmodule Phauxth.CustomConfirmTest do
 
   test "customize verify and get_user", %{conn: conn, email: email} do
     %{params: params} = conn(:get, "/confirm?key=" <> email) |> fetch_query_params
-    {:ok, user} = CustomConfirm.verify(params, TestAccounts, conn: conn)
+    {:ok, user} = CustomConfirm.verify(params, conn: conn)
     assert user.email == "ray@example.com"
   end
 end

--- a/test/custom_login_test.exs
+++ b/test/custom_login_test.exs
@@ -2,17 +2,17 @@ defmodule Phauxth.CustomLoginTest do
   use ExUnit.Case
   use Plug.Test
 
-  alias Phauxth.{CustomLogin, TestAccounts}
+  alias Phauxth.{CustomLogin}
 
   test "customize verify to use pass instead of password in params" do
     params = %{"email" => "fred+1@example.com", "pass" => "h4rd2gU3$$"}
-    {:ok, %{email: email}} = CustomLogin.verify(params, TestAccounts)
+    {:ok, %{email: email}} = CustomLogin.verify(params)
     assert email == "fred+1@example.com"
   end
 
   test "customize check_pass to change algorithm based on hash prefix" do
     params = %{"email" => "frank@example.com", "pass" => "h4rd2gU3$$"}
-    {:ok, %{email: email}} = CustomLogin.verify(params, TestAccounts)
+    {:ok, %{email: email}} = CustomLogin.verify(params)
     assert email == "frank@example.com"
   end
 end

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -3,70 +3,70 @@ defmodule Phauxth.LoginTest do
   use Plug.Test
   import ExUnit.CaptureLog
 
-  alias Phauxth.{Login, TestAccounts}
+  alias Phauxth.{Login}
 
   test "login succeeds with email" do
     params = %{"email" => "fred+1@example.com", "password" => "h4rd2gU3$$"}
-    {:ok, %{email: email}} = Login.verify(params, TestAccounts)
+    {:ok, %{email: email}} = Login.verify(params)
     assert email == "fred+1@example.com"
   end
 
   test "login succeeds with username" do
     params = %{"username" => "fred", "password" => "h4rd2gU3$$"}
-    {:ok, %{username: username}} = Login.verify(params, TestAccounts)
+    {:ok, %{username: username}} = Login.verify(params)
     assert username == "fred"
   end
 
   test "login fails for incorrect password" do
     params = %{"email" => "fred+1@example.com", "password" => "oohwhatwasitagain"}
-    {:error, message} = Login.verify(params, TestAccounts)
+    {:error, message} = Login.verify(params)
     assert message =~ "Invalid credentials"
   end
 
   test "login fails for invalid username" do
     params = %{"username" => "dick", "password" => "h4rd2gU3$$"}
-    {:error, message} = Login.verify(params, TestAccounts)
+    {:error, message} = Login.verify(params)
     assert message =~ "Invalid credentials"
   end
 
   test "login fails for invalid email" do
     params = %{"email" => "dick@example.com", "password" => "h4rd2gU3$$"}
-    {:error, message} = Login.verify(params, TestAccounts)
+    {:error, message} = Login.verify(params)
     assert message =~ "Invalid credentials"
   end
 
   test "output to current_user does not contain password_hash" do
     params = %{"email" => "fred+1@example.com", "password" => "h4rd2gU3$$"}
-    {:ok, user} = Login.verify(params, TestAccounts)
+    {:ok, user} = Login.verify(params)
     refute Map.has_key?(user, :password_hash)
     refute Map.has_key?(user, :otp_secret)
   end
 
   test "login with different crypto module" do
     params = %{"email" => "frank@example.com", "password" => "h4rd2gU3$$"}
-    {:ok, %{email: email}} = Login.verify(params, TestAccounts, crypto: Comeonin.Argon2)
+    {:ok, %{email: email}} = Login.verify(params, crypto: Comeonin.Argon2)
     assert email == "frank@example.com"
   end
 
   test "login with different crypto module fails for wrong password" do
     params = %{"email" => "frank@example.com", "password" => "password"}
-    {:error, message} = Login.verify(params, TestAccounts, crypto: Comeonin.Argon2)
+    {:error, message} = Login.verify(params, crypto: Comeonin.Argon2)
     assert message =~ "Invalid credentials"
   end
 
   test "login with encrypted_password set as key" do
     params = %{"email" => "eddie@example.com", "password" => "h4rd2gU3$$"}
-    {:ok, %{email: email}} = Login.verify(params, TestAccounts, crypto: Comeonin.Argon2)
+    {:ok, %{email: email}} = Login.verify(params, crypto: Comeonin.Argon2)
     assert email == "eddie@example.com"
   end
 
   test "login with additional information to use different schemas" do
     params = %{"email" => "brian@example.com", "role" => "user", "password" => "h4rd2gU3$$"}
-    {:ok, %{email: email, role: role}} = Login.verify(params, TestAccounts)
+    {:ok, %{email: email, role: role}} = Login.verify(params)
     assert email == "brian@example.com"
     assert role == "user"
     params = %{"email" => "brian@example.com", "role" => "admin", "password" => "h4rd2gU3$$"}
-    {:ok, %{email: email, role: role}} = Login.verify(params, TestAccounts)
+    {:ok, %{email: email, role: role}} = Login.verify(params)
     assert email == "brian@example.com"
     assert role == "admin"
   end
@@ -74,13 +74,13 @@ defmodule Phauxth.LoginTest do
   test "login with custom metadata for logging" do
     assert capture_log(fn ->
              params = %{"email" => "fred+1@example.com", "password" => "h4rd2gU3$$"}
-             {:ok, _} = Login.verify(params, TestAccounts, log_meta: [path: "/sessions/create"])
+             {:ok, _} = Login.verify(params, log_meta: [path: "/sessions/create"])
            end) =~ ~s(user=1 message="successful login" path=/sessions/create)
   end
 
   test "raises an error if no password is found in the params" do
     assert_raise ArgumentError, "No password found in the params", fn ->
-      {:ok, _} = Login.verify(%{"no_key" => "no_key"}, TestAccounts)
+      {:ok, _} = Login.verify(%{"no_key" => "no_key"})
     end
   end
 

--- a/test/remember_test.exs
+++ b/test/remember_test.exs
@@ -18,8 +18,8 @@ defmodule Phauxth.RememberTest do
   end
 
   test "init function" do
-    assert Remember.init([]) == {{604_800, Phauxth.Accounts, []}, []}
-    assert Remember.init(max_age: 100) == {{100, Phauxth.Accounts, [max_age: 100]}, []}
+    assert Remember.init([]) == {{604_800, TestAccounts, []}, []}
+    assert Remember.init(max_age: 100) == {{100, TestAccounts, [max_age: 100]}, []}
   end
 
   test "call remember with default options", %{conn: conn} do

--- a/test/support/custom_confirm.exs
+++ b/test/support/custom_confirm.exs
@@ -1,7 +1,11 @@
 defmodule Phauxth.CustomConfirm do
   use Phauxth.Confirm.Base
 
-  def verify(%{"key" => key}, user_context, opts) do
+  alias Phauxth.Config
+
+  def verify(%{"key" => key}, opts) do
+    user_context = Keyword.get(opts, :user_context, Config.user_context())
+    
     get_user(opts[:conn], {key, 600, user_context, opts})
     |> report(opts[:mode], [])
   end

--- a/test/support/custom_login.exs
+++ b/test/support/custom_login.exs
@@ -1,7 +1,11 @@
 defmodule Phauxth.CustomLogin do
   use Phauxth.Login.Base
 
-  def verify(%{"pass" => password} = params, user_context, opts) do
+  alias Phauxth.Config
+
+  def verify(%{"pass" => password} = params, opts) do
+    user_context = Keyword.get(opts, :user_context, Config.user_context())
+
     user_context.get_by(params)
     |> check_pass(password, Comeonin.Bcrypt, opts)
     |> report("Hi, how's it going?", [])

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -9,6 +9,7 @@ Code.require_file("support/user_helper.exs", __DIR__)
 
 Application.put_env(:phauxth, :endpoint, PhauxthWeb.Endpoint)
 Application.put_env(:phauxth, :token_salt, Phauxth.Config.gen_token_salt())
+Application.put_env(:phauxth, :user_context, Phauxth.TestAccounts)
 
 defmodule PhauxthWeb.Endpoint do
   def config(:secret_key_base), do: String.duplicate("abcdef0123456789", 8)


### PR DESCRIPTION
As we able to use user_context config. So, I want to remove user_context argument from Login.Base and Confirm.Base, and move the user_context into opts with the default given by Config.user_context().